### PR TITLE
Upgrade Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2</version>
+        <version>2.4</version>
         <executions>
           <execution>
             <id>falcon-jar</id>


### PR DESCRIPTION
The project uses a very old version of `maven-compiler-plugin`. Upgrade it and the other Maven plugins to the most recent versions.
