### PR TITLE
Fix performance test

### DIFF
--- a/falcon-perf-test/src/main/java/falcon/fix/perf/ClientPerfTest.java
+++ b/falcon-perf-test/src/main/java/falcon/fix/perf/ClientPerfTest.java
@@ -54,7 +54,7 @@ public class ClientPerfTest {
 
       for (;;) {
         Message msg = session.recv();
-        if (msg == null) {
+        if (msg != null) {
           break;
         }
       }


### PR DESCRIPTION
Actually await for an Execution Report before proceeding to the next iteration.