### PR TITLE
Wait until connected for non-loopback test

### DIFF
--- a/falcon-perf-test/src/main/java/falcon/fix/perf/ClientPerfTest.java
+++ b/falcon-perf-test/src/main/java/falcon/fix/perf/ClientPerfTest.java
@@ -100,7 +100,7 @@ public class ClientPerfTest {
     socket.configureBlocking(false);
     socket.setOption(TCP_NODELAY, true);
     socket.connect(addr);
-    socket.finishConnect();
+    while (!socket.finishConnect());
     return socket;
   }
 


### PR DESCRIPTION
Tiny fix to make it connect over non-loopback.
