### PR TITLE
add SessionTest for get a message's all fields

### DIFF
--- a/falcon/src/test/java/falcon/fix/SessionTest.java
+++ b/falcon/src/test/java/falcon/fix/SessionTest.java
@@ -1,0 +1,30 @@
+package falcon.fix;
+
+import java.nio.ByteBuffer;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class SessionTest {
+
+  private final String strStepPart = "8=FIX\0019=32\00135=A\00149=N001\00156=T002\001";
+  private ByteBuffer msgBuf = ByteBuffer.allocate(1024);
+  
+  @Test
+  public void ParseString() throws Exception {
+    byte[] msgBytes = strStepPart.getBytes();
+    msgBuf.put(msgBytes);
+    msgBuf.flip();    
+    Protocol.match(msgBuf, 8);
+    assertEquals(32, Protocol.matchInt(msgBuf, 9));
+    assertEquals(35, Protocol.parseInt(msgBuf, (byte)'='));
+    assertEquals("A", new String(Protocol.parseString(msgBuf, (byte)0x01).data));
+    msgBuf.get();
+    assertEquals(49, Protocol.parseInt(msgBuf, (byte)'='));
+    assertEquals("N001", new String(Protocol.parseString(msgBuf,  (byte)0x01).data));
+    msgBuf.get();
+    assertEquals(56, Protocol.parseInt(msgBuf, (byte)'='));
+    assertEquals("T002", new String(Protocol.parseString(msgBuf,  (byte)0x01).data));           
+    msgBuf.clear();
+
+  }
+}


### PR DESCRIPTION
In Session.rev()  method, get a message's all fields with below code:
      while (rxBuf.position() < checksumOffset) {
        int tag = Protocol.parseInt(rxBuf, (byte)'=');
        ByteString value = Protocol.parseString(rxBuf, (byte)0x01);
        fields.add(new Field(tag, value));
      }
      rxBuf.position(endOffset);
the tag number is error. Should add the rxBuf.get() to pass the (byte)0x01．Add the SessionTest for this.